### PR TITLE
[merge / 26-input-component-ui] ✨ input 컴포넌트 구현

### DIFF
--- a/src/components/common/Input.vue
+++ b/src/components/common/Input.vue
@@ -1,0 +1,64 @@
+<template>
+  <input
+    :class="[
+      'text-hc-gray bg-hc-white focus:outline-none flex items-center justify-center',
+      inputVar[variant],
+      inputSize[size],
+      inputBorderRadius[borderRadius],
+      className,
+    ]"
+    v-bind="otherProps"
+  />
+</template>
+
+<script>
+import { defineComponent } from "vue";
+
+export default defineComponent({
+  name: "Input",
+  props: {
+    variant: {
+      type: String,
+      validator: (value) => ["shadowed", "custom"].includes(value),
+    },
+    size: {
+      type: String,
+      required: true,
+      validator: (value) => ["xs", "sm", "md", "lg", "xl"].includes(value),
+    },
+    borderRadius: {
+      type: String,
+      required: true,
+      validator: (value) => ["md", "lg"].includes(value),
+    },
+    className: {
+      type: String,
+      default: "",
+    },
+  },
+  setup(props, { attrs }) {
+    const inputVar = {
+      shadowed: "shadow-blue",
+      custom: "",
+    };
+
+    const inputSize = {
+      xs: "w-[368px] h-[63px] text-[24px] pl-[40px]",
+      sm: "w-[480px] h-[63px] text-[24px] pl-[40px]",
+      md: "w-[615px] h-[45px] text-[20px] pl-[16px]",
+      lg: "w-[830px] h-[63px] text-[24px] pl-[40px]",
+      xl: "w-[941px] h-[45px] text-[20px] pl-[16px]",
+    };
+    const inputBorderRadius = {
+      md: "rounded-[20px]",
+      lg: "rounded-[70px]",
+    };
+    return {
+      inputVar,
+      inputSize,
+      inputBorderRadius,
+      otherProps: attrs,
+    };
+  },
+});
+</script>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -2,7 +2,11 @@
 export default {
   content: ["./index.html", "./src/**/*.{js,ts,jsx,tsx,vue}"],
   theme: {
-    extend: {},
+    extend: {
+      boxShadow: {
+        blue: "-4px 4px 50px 0px rgba(114, 158, 203, 0.70)",
+      },
+    },
     screens: {
       sm: "640px",
 


### PR DESCRIPTION
## #️⃣연관된 이슈
- close #26 

## 🪄변경 사항
- 로그인, 회원가입, 커뮤니티, 마이페이지에 공통적으로 사용할 input 컴포넌트 구현
- `size`, `borderRadius`: 필수 속성.
- `variant`: 선택 속성. `shadowed`를 선택하면 input 뒤에 커스텀된 파란색 그림자가 적용됨.

## 🖼️결과 화면 (선택) 
<img width="809" alt="image" src="https://github.com/user-attachments/assets/0b7b3336-4274-43ad-a3a3-5f5422c063b7" />


## 🗨️리뷰어에게 전할 말 (선택) 
지정해놓은 `size`나 `borderRadius` 의 값들 외에 추가로 필요하신 값이 있다면 tailwind css를 사용해 class로 <태그> 내에서 직접 지정할 수 있습니다 ♪(´▽｀)