### PR TITLE
[merge / 28-button-component-ui] ✨ Button 컴포넌트 구현

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,10 +1,22 @@
 <!DOCTYPE html>
 <html lang="">
   <head>
-    <meta charset="UTF-8">
-    <link rel="icon" href="/favicon.ico">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta charset="UTF-8" />
+    <link rel="icon" href="/favicon.ico" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Vite App</title>
+    <link
+      rel="stylesheet"
+      as="style"
+      crossorigin
+      href="https://cdn.jsdelivr.net/gh/ungveloper/web-fonts/Pretendard/font-face.css"
+    />
+    <link
+      rel="stylesheet"
+      as="style"
+      crossorigin
+      href="https://cdn.jsdelivr.net/gh/ungveloper/web-fonts/Pretendard/font-family.css"
+    />
   </head>
   <body>
     <div id="app"></div>

--- a/src/components/common/Button.vue
+++ b/src/components/common/Button.vue
@@ -1,0 +1,59 @@
+<template>
+  <button
+    :class="[
+      'focus:outline-none flex items-center justify-center',
+      buttonVar[variant],
+      buttonSize[size],
+      className,
+    ]"
+    v-bind="otherProps"
+  >
+    <slot />
+  </button>
+</template>
+
+<script>
+import { defineComponent } from "vue";
+
+export default defineComponent({
+  name: "Button",
+  props: {
+    variant: {
+      type: String,
+      required: true,
+      validator: (value) =>
+        ["filled", "outlined", "shadowed", "custom"].includes(value),
+    },
+    size: {
+      type: String,
+      required: true,
+      validator: (value) => ["sm", "md", "lg"].includes(value),
+    },
+
+    className: {
+      type: String,
+      default: "",
+    },
+  },
+  setup(props, { attrs }) {
+    const buttonVar = {
+      filled: "bg-hc-blue text-hc-white",
+      regular: "text-hc-blue bg-hc-white",
+      shadowed: "shadow-blue bg-hc-blue text-hc-white",
+      custom: "",
+    };
+
+    const buttonSize = {
+      sm: "w-[50px] h-[50px] rounded-[70px]",
+      md: "w-[160px] h-[48px] text-[16px] rounded-[20px]",
+      lg: "w-[480px] h-[63px] text-[24px] rounded-[70px] font-semibold",
+    };
+
+    return {
+      buttonVar,
+      buttonSize,
+      otherProps: attrs,
+    };
+  },
+});
+</script>


### PR DESCRIPTION
## #️⃣연관된 이슈
- close #28 

## 🪄변경 사항
- 로그인, 회원가입, 꿈기록, 일기장, 커뮤니티, 마이페이지, 유저페이지 등 서비스 전체에서 사용할 button 컴포넌트 구현
- `variant`, `size` : 필수 속성 
- Pretendard 폰트 전역으로 적용 

## 🖼️결과 화면 (선택) 
<img width="414" alt="image" src="https://github.com/user-attachments/assets/dcf999c1-1b61-449b-b280-f3d5927a8a0b" />


## 🗨️리뷰어에게 전할 말 (선택) 
지정해놓은 값들 외에 추가로 필요하신 값이 있다면 tailwind css를 사용해 class로 <태그> 내에서 직접 지정할 수 있습니다 
( •̀ ω •́ )✧