### PR TITLE
[merge / 76-community-page-meatballs-menu] ✨ Feat: 커뮤니티 게시물 상세페이지 드롭다운 메뉴 구현

### DIFF
--- a/src/components/common/MeatballsMenu.vue
+++ b/src/components/common/MeatballsMenu.vue
@@ -1,0 +1,80 @@
+<script setup>
+import { ref, onMounted, onUnmounted } from "vue";
+import { Icon } from "@iconify/vue";
+
+defineProps(["menuItems"]);
+
+const isOpen = ref(false);
+
+const toggleMenu = () => {
+  isOpen.value = !isOpen.value;
+};
+
+const closeMenuOnOutsideClick = (event) => {
+  const dropdown = document.querySelector(".dropdown-container");
+  if (dropdown && !dropdown.contains(event.target)) {
+    isOpen.value = false;
+  }
+};
+
+onMounted(() => {
+  window.addEventListener("click", closeMenuOnOutsideClick);
+});
+
+onUnmounted(() => {
+  window.removeEventListener("click", closeMenuOnOutsideClick);
+});
+</script>
+
+<template>
+  <div
+    class="relative inline-block dropdown-container"
+    @click.stop="toggleMenu"
+  >
+    <!-- Meatballs Icon -->
+    <div class="flex gap-1 cursor-pointer">
+      <span class="w-1.5 h-1.5 bg-hc-gray rounded-full"></span>
+      <span class="w-1.5 h-1.5 bg-hc-gray rounded-full"></span>
+      <span class="w-1.5 h-1.5 bg-hc-gray rounded-full"></span>
+    </div>
+
+    <div
+      v-if="isOpen"
+      class="absolute right-0 z-50 w-40 mt-2 bg-white border border-gray-200 rounded-lg shadow-lg"
+    >
+      <ul class="py-1">
+        <li
+          v-for="item in menuItems"
+          :key="item.label"
+          @click="item.action && item.action()"
+          class="flex items-center gap-2 px-4 py-2 text-sm text-gray-700 cursor-pointer hover:bg-hc-gray/20"
+        >
+          <RouterLink
+            v-if="item.link"
+            :to="item.link"
+            class="flex items-center w-full gap-2 text-left"
+          >
+            <Icon
+              v-if="item.icon"
+              :icon="item.icon"
+              :width="item.width || 20"
+              :height="item.height || 20"
+              :color="item.color || '#757575'"
+            />
+            <span>{{ item.label }}</span>
+          </RouterLink>
+          <div v-else class="flex items-center gap-2">
+            <Icon
+              v-if="item.icon"
+              :icon="item.icon"
+              :width="item.width || 20"
+              :height="item.height || 20"
+              :color="item.color || '#757575'"
+            />
+            <span>{{ item.label }}</span>
+          </div>
+        </li>
+      </ul>
+    </div>
+  </div>
+</template>

--- a/src/pages/community-pages/PostDetails.vue
+++ b/src/pages/community-pages/PostDetails.vue
@@ -4,7 +4,7 @@ import dateConverter from "../../utils/dateConveter";
 import Button from "@/components/common/Button.vue";
 import Input from "@/components/common/Input.vue";
 
-import { onMounted, ref, watch } from "vue";
+import { computed, onMounted, ref, watch } from "vue";
 import { useRoute } from "vue-router";
 import { register } from "swiper/element/bundle";
 import { Icon } from "@iconify/vue";
@@ -16,6 +16,7 @@ import {
   fetchImagesFromSupabase,
   deleteImagesFromFolder,
 } from "@/api/api-community/imgsApi";
+import MeatballsMenu from "@/components/common/MeatballsMenu.vue";
 
 const authStore = useAuthStore();
 
@@ -154,6 +155,21 @@ onMounted(async () => {
   }
 });
 
+const menuItems = computed(() => [
+  {
+    label: "Edit Post",
+    icon: "material-symbols:edit-square-outline-rounded",
+    link: `/${category}/${post.value.id}/update-post`, // RouterLink 경로
+    color: "#757575",
+  },
+  {
+    label: "Delete Post",
+    icon: "ic:round-delete",
+    action: () => fetchDeletePost(post.value.id), // 클릭 시 함수 호출
+    color: "#ed4848",
+  },
+]);
+
 register();
 </script>
 <template>
@@ -177,24 +193,8 @@ register();
         >팔로잉</Button
       >
 
-      <div class="flex gap-2" v-if="author.id === authStore.profile.id">
-        <RouterLink :to="`/${category}/${post.id}/update-post`">
-          <Icon
-            icon="material-symbols:edit-square-outline-rounded"
-            class="cursor-pointer"
-            width="24"
-            height="24"
-            color="#757575"
-          />
-        </RouterLink>
-        <Icon
-          @click="fetchDeletePost(post.id)"
-          icon="ic:round-delete"
-          class="cursor-pointer"
-          width="24"
-          height="24"
-          color="#ed4848"
-        />
+      <div v-if="author.id === authStore.profile.id">
+        <MeatballsMenu :menuItems="menuItems" />
       </div>
     </div>
 


### PR DESCRIPTION
## #️⃣연관된 이슈
- close #76 

## 🪄변경 사항
- 커뮤니티 게시물 상세페이지 드롭다운 메뉴 구현

## 🖼️결과 화면 (선택) 
<img width="1098" alt="스크린샷 2025-01-23 오전 10 08 22" src="https://github.com/user-attachments/assets/93e11a6e-dd70-4fab-b387-8dbc984610bc" />
