### PR TITLE
[merge / 108-implement-before-and-after-sidebar-login]✨ Feat: 사이드 바 로그인 회원 연동, 자기소개 16자 제한

### DIFF
--- a/src/components/common/Input.vue
+++ b/src/components/common/Input.vue
@@ -12,6 +12,7 @@
       :type="currentType"
       :value="modelValue"
       @input="$emit('update:modelValue', $event.target.value)"
+      :maxlength="maxlength"
       v-bind="otherProps"
     />
     <button
@@ -70,6 +71,10 @@ export default defineComponent({
     isProfilePage: {
       type: Boolean,
       default: false,
+    },
+    maxlength: {
+      type: Number,
+      default: null, // 필요 시 기본값 설정
     },
   },
   setup(props, { attrs }) {

--- a/src/components/common/Sidebar.vue
+++ b/src/components/common/Sidebar.vue
@@ -1,40 +1,33 @@
 <script setup>
-import { ref, onMounted, computed } from "vue";
 import { useSidebarStore } from "../../store/sidebar"; // Pinia store import
 import DropDownCommunity from "./DropDownCommunity.vue";
 import { Icon } from "@iconify/vue";
-import sidebarHr from "../../../public/assets/icons/sidebar_hr.svg";
 import Headers from "./Headers.vue";
 import { RouterLink } from "vue-router";
 import { useRouter } from "vue-router";
 import { useAuthStore } from "@/store/authStore";
+import { useModalStore } from "@/store/modalStore";
 
+const modalStore = useModalStore();
 const authStore = useAuthStore();
 const sidebarStore = useSidebarStore(); // Pinia store 초기화
 const router = useRouter();
 
-const showNotifications = ref(false);
-
 async function handleLogout() {
-  const success = await authStore.logout();
-  if (success) {
-    alert("로그아웃 성공!");
-    router.push("/");
-  }
-}
-
-const currentUserId = computed(() => authStore.user?.id);
-
-onMounted(async () => {
-  while (!currentUserId.value) {
-    await new Promise((resolve) => setTimeout(resolve, 100));
-  }
-  console.log("Current User ID:", currentUserId.value);
-  await notificationsStore.fetchNotifications(currentUserId.value);
-});
-
-function handleCloseNotification(notificationId) {
-  notificationsStore.markNotificationAsRead(notificationId);
+  modalStore.addModal({
+    title: "로그아웃",
+    content: "로그아웃 하시겠습니까?",
+    btnText: "확인",
+    cancelBtnText: "취소",
+    isOneBtn: false,
+    onClick: async () => {
+      const success = await authStore.logout();
+      if (success) {
+        modalStore.modals = [];
+        router.push("/");
+      }
+    },
+  });
 }
 </script>
 
@@ -54,22 +47,58 @@ function handleCloseNotification(notificationId) {
     <!-- 사이드바 콘텐츠 -->
     <div>
       <span class="block h-[1px] w-full bg-hc-white/30" />
-      <div class="py-[10px] flex flex-col gap-[15px]">
-        <RouterLink class="flex items-center gap-[10px]" to="/mypage/profile">
-          <img
-            class="w-10 h-10 rounded-full"
-            src="https://cdn.pixabay.com/photo/2019/11/08/11/56/kitten-4611189_1280.jpg"
-            alt="사용자 프로필 이미지입니다."
-          />
-          <div class="text-hc-white">
-            <p class="font-semibold">@Mala_love</p>
-            <p class="text-hc-black">저는 마라를 사랑합니다.</p>
-          </div>
-        </RouterLink>
+      <div>
+        <!-- 로그인 상태 -->
+        <div v-if="authStore.user" class="py-[10px] flex flex-col gap-[15px]">
+          <RouterLink
+            class="flex items-center gap-[10px] hover:opacity-80"
+            :to="`/mypage/profile/${authStore.user.id}`"
+          >
+            <img
+              class="w-10 h-10 rounded-full"
+              :src="authStore.profile.profile_url"
+              alt="사용자의 프로필 이미지입니다."
+            />
+            <div class="text-hc-white">
+              <p
+                class="font-semibold"
+                :style="{ fontSize: 'clamp(16px, 2.5vw, 20px)' }"
+              >
+                @{{ authStore.profile.username }}
+              </p>
+              <p
+                class="text-hc-black"
+                :style="{ fontSize: 'clamp(10px, 2vw, 13px)' }"
+              >
+                {{ authStore.profile.profile_bio }}
+              </p>
+            </div>
+          </RouterLink>
+        </div>
+
+        <!-- 비로그인 상태 -->
+        <div v-else class="py-[10px] flex flex-col gap-[15px]">
+          <RouterLink
+            class="flex items-center gap-[10px] hover:opacity-80"
+            to="/login"
+          >
+            <img
+              class="w-10 h-10 rounded-full"
+              src="/assets/imgs/unknownUser.png"
+              alt="알 수 없는 사용자 이미지입니다."
+            />
+            <button
+              class="text-hc-white font-semibold hover:underline text-[20px]"
+            >
+              로그인
+            </button>
+          </RouterLink>
+        </div>
 
         <div class="flex justify-between">
           <div>
             <Icon
+              v-if="authStore.user"
               id="logout-icon"
               icon="material-symbols:logout-rounded"
               @click="handleLogout"
@@ -85,44 +114,12 @@ function handleCloseNotification(notificationId) {
               width="1.5rem"
               height="1.5rem"
               style="color: #ffffff"
-              class="cursor-pointer"
             />
           </div>
         </div>
       </div>
 
       <span class="block h-[1px] w-full bg-hc-white/30" />
-    </div>
-
-    <div
-      v-if="showNotifications && notificationsStore.notifications.length"
-      class="mt-[1rem] bg-[rgba(255,255,255,0.5)] rounded-[1.25rem] text-[0.85rem] text-[#000] px-[0.9375rem] pt-[0.9375rem] sm:flex sm:flex-col gap-[0.3125rem] max-h-[11rem] overflow-y-auto no-scrollbar"
-    >
-      <template
-        v-for="notification in notificationsStore.notifications"
-        :key="notification.id"
-      >
-        <p v-if="notification.type === 'follow'">
-          <span class="font-semibold">@{{ notification.sender.username }}</span>
-          님이 회원님을 팔로우 했습니다.
-        </p>
-        <p v-else-if="notification.type === 'like'">
-          <span class="font-semibold">@{{ notification.sender.username }}</span
-          >님이 회원의 게시글에 좋아요를 눌렀습니다.
-        </p>
-        <p v-else-if="notification.type === 'comment'">
-          <span class="font-semibold">@{{ notification.sender.username }}</span
-          >님이 회원의 게시글에 댓글을 남겼습니다.
-        </p>
-        <img :src="sidebarHr" alt="구분선 이미지" />
-      </template>
-
-      <button
-        class="underline text-[#757575] text-center mb-[0.5625rem] cursor-pointer"
-        @click="showNotifications = false"
-      >
-        닫기
-      </button>
     </div>
 
     <div class="flex gap-4 py-3 xm:flex-col xm:py-[25%]">
@@ -153,12 +150,3 @@ function handleCloseNotification(notificationId) {
     <DropDownCommunity />
   </div>
 </template>
-<style scoped>
-.no-scrollbar::-webkit-scrollbar {
-  display: none; /* for Chrome, Safari, and Opera */
-}
-.no-scrollbar {
-  -ms-overflow-style: none; /* for Internet Explorer and Edge */
-  scrollbar-width: none; /* for Firefox */
-}
-</style>

--- a/src/pages/Follow.vue
+++ b/src/pages/Follow.vue
@@ -35,6 +35,9 @@ const allUsers = computed(() => {
 const initializeData = async () => {
   loggedInUserId.value = authStore.profile.id;
 
+  // 전체 사용자 데이터
+  await followStore.fetchAllUsers();
+
   // 프로필 유저 이름 가져오기
   const profileUser = followStore.allUsers.find(
     (user) => user.id === profileUserId
@@ -46,9 +49,6 @@ const initializeData = async () => {
 
   // 프로필 주인의 팔로워/팔로잉 데이터
   await followStore.fetchFollowData(profileUserId);
-
-  // 전체 사용자 데이터
-  await followStore.fetchAllUsers();
 };
 
 // 팔로우 토글
@@ -87,7 +87,7 @@ onMounted(() => {
 
     <!-- 메인 카드 -->
     <div
-      class="w-[642px] h-[1250px] bg-hc-white/30 border-[7px] border-hc-white/50 rounded-[20px] relative p-8"
+      class="w-[642px] h-[1250px] bg-hc-blue/20 border-[7px] border-hc-white/50 rounded-[20px] relative p-8"
       style="box-shadow: -4px 4px 50px 0 rgba(114, 158, 203, 0.7)"
     >
       <div class="flex flex-col h-full">
@@ -160,7 +160,8 @@ onMounted(() => {
               v-for="user in allUsers"
               :key="user.id"
               @click="goToProfile(user.id)"
-              class="flex items-center justify-between p-4 bg-hc-white/60 rounded-[10px] shadow-sm"
+              class="flex items-center justify-between p-4 rounded-[10px] shadow-sm"
+              style="background-color: rgba(255, 255, 255, 0.5) !important"
             >
               <div class="flex items-center gap-4">
                 <img
@@ -179,7 +180,6 @@ onMounted(() => {
                   followStore.isUserFollowed(user.id) ? 'regular' : 'filled'
                 "
                 size="xl"
-                class="border border-hc-blue"
               >
                 {{ followStore.isUserFollowed(user.id) ? "팔로잉" : "팔로우" }}
               </Button>

--- a/src/pages/Join.vue
+++ b/src/pages/Join.vue
@@ -63,6 +63,14 @@ watch(
   }
 );
 
+// 자기소개 입력값 실시간 제어
+const handleProfileBioInput = (event) => {
+  const value = event.target.value;
+  if (value.length > 16) {
+    registerCredentials.value.profile_bio = value.slice(0, 16);
+  }
+};
+
 const checkEmail = async () => {
   const email = registerCredentials.value?.email?.trim();
 
@@ -106,7 +114,7 @@ const checkUsername = async () => {
   // 한글, 영문, 숫자를 허용하고 4~12자 제한
   if (!username.trim() || !/^[가-힣a-zA-Z0-9]{4,12}$/.test(username)) {
     usernameError.value =
-      "아이디는 4~12자 사이여야 하며, 한글, 영문, 숫자만 사용할 수 있습니다.";
+      "닉네임는 4~12자 사이여야 하며, 한글, 영문, 숫자만 사용할 수 있습니다.";
     usernameAvailable.value = false; // 사용 불가능 상태
     return;
   }
@@ -119,15 +127,15 @@ const checkUsername = async () => {
       .single();
 
     if (data) {
-      usernameError.value = "이미 사용 중인 아이디입니다.";
+      usernameError.value = "이미 사용 중인 닉네임입니다.";
       usernameAvailable.value = false; // 사용 불가능 상태
     } else {
       usernameError.value = "";
       usernameAvailable.value = true; // 사용 가능 상태
     }
   } catch (error) {
-    console.error("아이디 확인 오류:", error.message);
-    usernameError.value = "아이디 확인 중 오류가 발생했습니다.";
+    console.error("닉네임 확인 오류:", error.message);
+    usernameError.value = "닉네임 확인 중 오류가 발생했습니다.";
     usernameAvailable.value = false; // 사용 불가능 상태
   }
 };
@@ -276,7 +284,7 @@ const register = async () => {
 
         <div>
           <label class="block mb-1 ml-10 text-xl font-semibold text-hc-blue"
-            >아이디</label
+            >닉네임</label
           >
           <div class="flex items-center">
             <Input
@@ -303,22 +311,34 @@ const register = async () => {
             v-else-if="usernameAvailable"
             class="text-green text-xs ml-10 mt-2"
           >
-            사용가능한 아이디입니다.
+            사용가능한 닉네임입니다.
           </p>
         </div>
 
         <div>
-          <label class="block mb-1 ml-10 text-xl font-semibold text-hc-blue"
-            >자기소개</label
-          >
+          <label class="block mb-1 ml-10 text-xl font-semibold text-hc-blue">
+            자기소개
+          </label>
           <Input
             type="text"
-            placeholder="자기소개를 입력해주세요"
+            placeholder="자기소개는 최대 16자입니다."
             v-model="registerCredentials.profile_bio"
+            @input="handleProfileBioInput"
+            :maxlength="16"
             variant="shadowed"
             size="sm"
             borderRadius="lg"
           />
+
+          <p
+            class="text-xs ml-10 mt-2"
+            :class="{
+              'text-red': registerCredentials.profile_bio.length === 16,
+              'text-green': registerCredentials.profile_bio.length < 16,
+            }"
+          >
+            {{ registerCredentials.profile_bio.length }}/16
+          </p>
         </div>
         <div>
           <label class="block mb-1 ml-10 text-xl font-semibold text-hc-blue"

--- a/src/pages/my-pages/ProfileEdit.vue
+++ b/src/pages/my-pages/ProfileEdit.vue
@@ -94,7 +94,13 @@ watch(
     confirmPasswordError.value = "";
   }
 );
-
+// 자기소개 입력값 실시간 제어
+const handleProfileBioInput = (event) => {
+  const value = event.target.value;
+  if (value.length > 16) {
+    userData.value.profile_bio = value.slice(0, 16);
+  }
+};
 // 사진 변경 처리 (미리보기)
 const handleImageChange = (event) => {
   const file = event.target.files[0];
@@ -190,7 +196,7 @@ const openConfirmationModal = () => {
     onClick: () => {
       modalStore.modals = []; // 모든 모달 닫기
       handleSave(); // 저장 로직 실행
-      router.push("/mypage/profile");
+      router.push("/");
     },
   });
 };
@@ -278,6 +284,8 @@ const openConfirmationModal = () => {
             >
               <Input
                 v-model="userData.profile_bio"
+                @input="handleProfileBioInput"
+                :maxlength="16"
                 type="text"
                 placeholder="자기소개를 입력해주세요"
                 size="lg"
@@ -286,6 +294,16 @@ const openConfirmationModal = () => {
                 :isProfilePage="true"
               />
             </div>
+
+            <p
+              class="text-xs ml-5 mt-2"
+              :class="{
+                'text-red': userData.profile_bio.length === 16,
+                'text-green': userData.profile_bio.length < 16,
+              }"
+            >
+              {{ userData.profile_bio.length }}/16
+            </p>
           </div>
 
           <!-- 비밀번호 변경 -->


### PR DESCRIPTION
## #️⃣연관된 이슈
- close #108 

## 🪄변경 사항
- 회원 가입, 프로필 변경 시 자기소개 글자 수 16자로 제한했습니다.
- 사이드 바 로그인한 유저로 데이터 연동하였습니다.

## 🖼️결과 화면 (선택) 
<img width="1259" alt="image" src="https://github.com/user-attachments/assets/84bd8cd1-ed73-42ab-9ec0-6b68f199b2ff" />
<img width="1250" alt="image" src="https://github.com/user-attachments/assets/5a57cade-f08e-4207-a9fd-dd978baae4fc" />
<img width="1262" alt="image" src="https://github.com/user-attachments/assets/067d3a00-44ea-4645-b51d-4a9406478e2d" />


## 🗨️리뷰어에게 전할 말 (선택) 
- ༼ つ ◕_◕ ༽つฅʕ•̫͡•ʔฅ༼ つ ◕_◕ ༽つฅʕ•̫͡•ʔฅヾ(⌐■_■)ノ♪┗|｀O′|┛