### PR TITLE
[merge / 103-diary-details-ui] :bug: fix: 매핑된 아이콘 불러오기와 상세에서 달력 바로가기

### DIFF
--- a/src/pages/diary-pages/DiaryDetails.vue
+++ b/src/pages/diary-pages/DiaryDetails.vue
@@ -4,6 +4,7 @@ import { useRoute } from "vue-router";
 import { Icon } from "@iconify/vue";
 import { useAuthStore } from "@/store/authStore";
 import { getDiaryById } from "@/api/api-diary/api";
+import { weatherIcons, faceIcons, getIconByName } from "@/utils/iconUtils";
 
 const route = useRoute();
 const diaryId = route.params.id;
@@ -82,12 +83,18 @@ const toggleModal = () => {
 
         <div class="flex items-center gap-2 justify-end ml-auto">
           <p class="text-xl xm:hidden sm:block">오늘의 기분</p>
-          <Icon :icon="diaryData.condition" class="w-6 h-6 text-hc-blue" />
+          <Icon
+            :icon="getIconByName(faceIcons, diaryData.condition)"
+            class="w-6 h-6 text-hc-blue"
+          />
         </div>
 
         <div class="flex items-center gap-2 justify-end">
           <p class="text-xl xm:hidden sm:block">오늘의 날씨</p>
-          <Icon :icon="diaryData.weather" class="w-6 h-6 text-hc-blue" />
+          <Icon
+            :icon="getIconByName(weatherIcons, diaryData.weather)"
+            class="w-6 h-6 text-hc-blue"
+          />
         </div>
 
         <!-- 더보기 버튼과 모달 -->
@@ -170,5 +177,19 @@ const toggleModal = () => {
         class="w-full aspect-video"
       ></iframe>
     </div>
+
+    <RouterLink to="/diary">
+      <v-fab
+        icon="$mdi-plus"
+        class="fixed scale-[110%] bottom-0 right-0 z-30 m-[80px]"
+      >
+        <Icon
+          icon="material-symbols:book-2-outline"
+          width="1.5rem"
+          height="1.5rem"
+          style="color: #729ecb"
+        />
+      </v-fab>
+    </RouterLink>
   </div>
 </template>

--- a/src/utils/iconUtils.js
+++ b/src/utils/iconUtils.js
@@ -1,0 +1,34 @@
+export const weatherIcons = [
+  { icon: "material-symbols:wb-sunny-outline-rounded", name: "sunny" },
+  { icon: "lsicon:cloudy-outline", name: "cloudy" },
+  { icon: "material-symbols:air-rounded", name: "windy" },
+  { icon: "material-symbols:rainy-outline", name: "rainy" },
+  { icon: "material-symbols:ac-unit-rounded", name: "snowy" },
+];
+
+export const faceIcons = [
+  {
+    icon: "material-symbols:sentiment-satisfied-outline-rounded",
+    name: "satisfied",
+  },
+  {
+    icon: "material-symbols:sentiment-neutral-outline-rounded",
+    name: "neutral",
+  },
+  {
+    icon: "material-symbols:sentiment-dissatisfied-outline-rounded",
+    name: "dissatisfied",
+  },
+  { icon: "material-symbols:sentiment-sad-outline-rounded", name: "sad" },
+  {
+    icon: "material-symbols:sentiment-extremely-dissatisfied-outline-rounded",
+    name: "extremely_dissatisfied",
+  },
+  {
+    icon: "material-symbols:sentiment-very-satisfied-outline-rounded",
+    name: "extremely_satisfied",
+  },
+];
+
+export const getIconByName = (icons, name) =>
+  icons.find((item) => item.name === name)?.icon || null;


### PR DESCRIPTION
## #️⃣연관된 이슈
- close #103 

## 🪄변경 사항
- 아이콘과 이름을 매핑해 수파베이스에 저장된 데이터로 아이콘을 호출했고, 달력 상세 페이지에서 달력전체로 갈 수 있는 하단 버튼 생성함

## 🖼️결과 화면 (선택) 
![image](https://github.com/user-attachments/assets/c777045b-b297-4780-85eb-7b769bca6e5f)


## 🗨️리뷰어에게 전할 말 (선택) 
