### PR TITLE
[merge / 141-reset-record-data] 🐛 fix: 꿈 기록 페이지의 데이터가 다른 페이지를 다녀와도 유지되는 오류 해결

### DIFF
--- a/src/pages/Home.vue
+++ b/src/pages/Home.vue
@@ -9,31 +9,31 @@ import { mdiReload } from "@mdi/js";
 const videos = ref([]);
 const isLoading = ref(true); // 로딩 상태 추가
 
-const fetchASMRVideos = async () => {
-  videos.value = [];
-  isLoading.value = true; // 로딩 상태 시작
-  const apiKey = import.meta.env.VITE_YOUTUBE_API_KEY;
-  const keyword = "asmr ambience";
-  const maxResults = 24;
+// const fetchASMRVideos = async () => {
+//   videos.value = [];
+//   isLoading.value = true; // 로딩 상태 시작
+//   const apiKey = import.meta.env.VITE_YOUTUBE_API_KEY;
+//   const keyword = "asmr ambience";
+//   const maxResults = 24;
 
-  try {
-    const response = await fetch(
-      `https://www.googleapis.com/youtube/v3/search?part=snippet&q=${keyword}&maxResults=${maxResults}&key=${apiKey}`
-    );
-    const data = await response.json();
+//   try {
+//     const response = await fetch(
+//       `https://www.googleapis.com/youtube/v3/search?part=snippet&q=${keyword}&maxResults=${maxResults}&key=${apiKey}`
+//     );
+//     const data = await response.json();
 
-    if (data.items && data.items.length > 0) {
-      const randomVideos = getRandomVideos(data.items, 4);
-      videos.value = randomVideos;
-    } else {
-      console.error("ASMR 영상이 없습니다.");
-    }
-  } catch (error) {
-    console.error("Error fetching ASMR videos:", error);
-  } finally {
-    isLoading.value = false; // 로딩 상태 종료
-  }
-};
+//     if (data.items && data.items.length > 0) {
+//       const randomVideos = getRandomVideos(data.items, 4);
+//       videos.value = randomVideos;
+//     } else {
+//       console.error("ASMR 영상이 없습니다.");
+//     }
+//   } catch (error) {
+//     console.error("Error fetching ASMR videos:", error);
+//   } finally {
+//     isLoading.value = false; // 로딩 상태 종료
+//   }
+// };
 
 const getRandomVideos = (arr, n) => {
   const mixed = arr.slice(0);
@@ -44,7 +44,7 @@ const getRandomVideos = (arr, n) => {
   return mixed.slice(0, n);
 };
 
-fetchASMRVideos();
+// fetchASMRVideos();
 </script>
 
 <template>
@@ -123,7 +123,7 @@ fetchASMRVideos();
             class="w-full max-h-[300px] object-cover"
           ></v-skeleton-loader>
         </li>
-        <li v-for="video in videos" :key="video.id.videoId" v-else>
+        <!-- <li v-for="video in videos" :key="video.id.videoId" v-else>
           <iframe
             :src="'https://www.youtube.com/embed/' + video.id.videoId"
             frameborder="0"
@@ -132,7 +132,7 @@ fetchASMRVideos();
             class="w-full max-h-[300px] rounded-[20px] object-cover h-auto"
             style="aspect-ratio: 16 / 9"
           ></iframe>
-        </li>
+        </li> -->
       </ul>
     </div>
   </div>

--- a/src/pages/Record.vue
+++ b/src/pages/Record.vue
@@ -11,6 +11,7 @@ import {
   mdiMicrophoneOff,
 } from "@mdi/js";
 import { ref, onMounted } from "vue";
+import { useRoute, onBeforeRouteLeave } from "vue-router";
 import { OpenAI } from "openai";
 import { useDiaryStore } from "@/store/diaryStore";
 import { checkDiaryExists } from "@/api/api-record/api";
@@ -35,6 +36,15 @@ const isGeneratingImage = ref(false);
 const emotion = ref("");
 const asmrVideo = ref(null);
 const isFetching = ref(false);
+
+//일기 작성 페이지를 제외한 다른 페이지 이동 시 데이터 초기화
+const route = useRoute();
+
+onBeforeRouteLeave((to) => {
+  if (to.path !== "/diary/write") {
+    diaryStore.resetData();
+  }
+});
 
 //음성 인식 시작
 const startListening = () => {

--- a/src/store/diaryStore.js
+++ b/src/store/diaryStore.js
@@ -20,5 +20,11 @@ export const useDiaryStore = defineStore("diary", {
     setYoutubeUrl(newYoutubeUrl) {
       this.youtubeUrl = newYoutubeUrl;
     },
+    resetData() {
+      this.content = "";
+      this.dreamAnalysis = "";
+      this.imgUrl = "";
+      this.youtubeUrl = "";
+    },
   },
 });


### PR DESCRIPTION
## #️⃣연관된 이슈
- close #141 

## 🪄변경 사항
- 꿈 기록 페이지의 데이터가 일기 작성 페이지를 제외한 다른 페이지로 이동하면 데이터가 초기화되도록 

## 🖼️결과 화면 (선택) 


## 🗨️리뷰어에게 전할 말 (선택) 
( •̀ ω •́ )y