### PR TITLE
[merge / 145-download-ai-image]✨ feat: AI 이미지 다운로드 구현

### DIFF
--- a/src/pages/Record.vue
+++ b/src/pages/Record.vue
@@ -206,6 +206,15 @@ const generateImage = async () => {
 };
 
 //이미지 다운로드
+const downloadImage = async () => {
+  const imgUrl = diaryStore.imgUrl;
+
+  const link = document.createElement("a");
+  link.href = imgUrl;
+  link.download = `${Date.now()}_dream_image.png`;
+  link.target = "_blank";
+  link.click();
+};
 
 //꿈 감정 분석
 const analyzeEmotion = async () => {
@@ -520,7 +529,12 @@ onMounted(async () => {
           class="w-full h-fit md:rounded-3xl"
         />
 
-        <Button size="xs" variant="regular" class="absolute bottom-4 right-4">
+        <Button
+          size="xs"
+          variant="regular"
+          class="absolute bottom-4 right-4"
+          @click="downloadImage"
+        >
           <v-icon>
             <svg
               xmlns="http://www.w3.org/2000/svg"


### PR DESCRIPTION
## #️⃣연관된 이슈
- close #145 

## 🪄변경 사항
- AI 이미지 다운로드 구현 

## 🖼️결과 화면 (선택) 
![image](https://github.com/user-attachments/assets/b71bd172-aa0d-4709-ad57-b35d24a4eedd)


## 🗨️리뷰어에게 전할 말 (선택) 
![image](https://github.com/user-attachments/assets/ffcec02f-6332-495d-8a97-b8dc0f762655)
이런 식으로 구현하고 싶었으나,

OpenAI의 DALL-E 3을 통해 생성된 이미지를 a 태그 없이 직접 다운로드하는 방법은 **OpenAI의 정책에 따라 제약**이 있을 수 있고, **서비스의 약관을 위반**할 수도 있다고 합니다. 😭
일반적으로는 OpenAI가 제공하는 방법, 즉 **API 응답에서 제공하는 URL을 통해 다운로드 하는 것을 권장**한다고 합니다. 

따라서 API 응답에서 제공하는 URL을 통해 **새 창에서 이미지를 다운로드** 할 수 있도록 구현하였습니다. 