### PR TITLE
[merge / 172-implementing-modal-window-mobile-screen] 🐛 Fix: 모달창 모바일용 화면 구현

### DIFF
--- a/src/components/common/Modal.vue
+++ b/src/components/common/Modal.vue
@@ -2,32 +2,34 @@
   <div
     v-for="modal in modals"
     :key="modal.id"
-    class="fixed top-0 left-0 bottom-0 right-0 bg-black/50 items-center justify-center z-[9999] hidden md:flex"
+    class="fixed top-0 left-0 bottom-0 right-0 bg-black/50 items-center justify-center z-[9999] flex"
   >
     <article
-      class="w-full max-w-[425px] h-[230px] bg-white rounded-[20px] p-6 flex flex-col items-center justify-center shadow-lg"
+      class="w-full max-w-[260px] md:max-w-[425px] h-[180px] md:h-[230px] bg-white rounded-[15px] md:rounded-[20px] p-4 md:p-6 flex flex-col items-center justify-center shadow-lg"
     >
       <!-- 제목 -->
-      <div class="text-[24px] font-bold text-center mb-2 text-black">
+      <div
+        class="text-[20px] md:text-[24px] font-bold text-center mb-2 text-black"
+      >
         {{ modal.title }}
       </div>
       <!-- 내용 -->
-      <div class="text-[20px] text-center mb-6">
+      <div class="text-[16px] md:text-[20px] text-center mb-4 md:mb-6">
         {{ modal.content }}
       </div>
       <!-- 버튼 -->
       <template v-if="modal.isOneBtn">
         <button
-          class="w-[125px] h-[45px] bg-hc-blue text-white text-lg rounded-[20px] font-normal"
+          class="w-[100px] md:w-[125px] h-[40px] md:h-[45px] bg-hc-blue text-white text-base md:text-lg rounded-[15px] md:rounded-[20px] font-normal"
           @click="modal.onClick ? modal.onClick() : closeModal(modal.id)"
         >
           {{ modal.btnText }}
         </button>
       </template>
       <template v-else>
-        <div class="flex items-center gap-4">
+        <div class="flex items-center gap-3 md:gap-4">
           <button
-            class="w-[125px] h-[45px] border border-hc-blue text-lg rounded-[20px] text-hc-blue font-normal"
+            class="w-[100px] md:w-[125px] h-[40px] md:h-[45px] border border-hc-blue text-base md:text-lg rounded-[15px] md:rounded-[20px] text-hc-blue font-normal"
             style="border-color: #729ecb !important"
             @click="closeModal(modal.id)"
           >
@@ -35,7 +37,7 @@
           </button>
 
           <button
-            class="w-[125px] h-[45px] border border-hc-blue text-lg bg-hc-blue text-white rounded-[20px] font-normal"
+            class="w-[100px] md:w-[125px] h-[40px] md:h-[45px] border border-hc-blue text-base md:text-lg bg-hc-blue text-white rounded-[15px] md:rounded-[20px] font-normal"
             @click="modal.onClick"
           >
             {{ modal.btnText }}


### PR DESCRIPTION
## #️⃣연관된 이슈
- close #이슈번호

## 🪄변경 사항
- 모바일에서도 모달창이 뜨게 만들었습니다..

## 🖼️결과 화면 (선택) 
<img width="382" alt="image" src="https://github.com/user-attachments/assets/91adf012-f9b2-4045-81b6-2781bf8e3079" />


## 🗨️리뷰어에게 전할 말 (선택) 
- 🤯ε=ε=ε=(~￣▽￣)~