### PR TITLE
[merge / 171-notification-logout-header-hidden] ✨Feat: 로그아웃 시에 헤더에서 알림 아이콘 숨김, 알림 삭제 버튼 모달창 적용

### DIFF
--- a/src/components/common/Headers.vue
+++ b/src/components/common/Headers.vue
@@ -89,7 +89,7 @@ onMounted(async () => {
       </div>
 
       <!-- 알림 바로가기 -->
-      <div id="noti-icon" class="relative">
+      <div v-if="authStore.isLoggedIn" id="noti-icon" class="relative">
         <router-link to="/notification" class="bg-transparent cursor-pointer">
           <Icon
             id="noti-icon"

--- a/src/components/common/Modal.vue
+++ b/src/components/common/Modal.vue
@@ -12,9 +12,7 @@
         {{ modal.title }}
       </div>
       <!-- 내용 -->
-      <div class="text-[20px] text-center mb-6">
-        {{ modal.content }}
-      </div>
+      <div class="text-[20px] text-center mb-6" v-html="modal.content"></div>
       <!-- 버튼 -->
       <template v-if="modal.isOneBtn">
         <button

--- a/src/pages/Notification.vue
+++ b/src/pages/Notification.vue
@@ -6,19 +6,30 @@ import { useNotificationsStore } from "@/store/notificationsStore";
 import supabase from "@/config/supabase";
 import { Icon } from "@iconify/vue";
 import Button from "@/components/common/Button.vue";
+import { useModalStore } from "@/store/modalStore";
 
 const router = useRouter();
 const authStore = useAuthStore();
 const notificationsStore = useNotificationsStore();
+const modalStore = useModalStore();
 
 const currentUserId = computed(() => authStore.user?.id);
 
 // 알림 삭제 핸들러
 async function handleDeleteAllNotifications() {
-  if (confirm("모든 알림을 삭제하시겠습니까? 이 작업은 되돌릴 수 없습니다.")) {
-    await notificationsStore.deleteAllNotifications(currentUserId.value);
-  }
+  modalStore.addModal({
+    title: "알림 삭제",
+    content: "모든 알림을 삭제하시겠습니까?<br>이 작업은 되돌릴 수 없습니다.",
+    btnText: "확인",
+    cancelBtnText: "취소",
+    isOneBtn: false,
+    onClick: async () => {
+      await notificationsStore.deleteAllNotifications(currentUserId.value);
+      modalStore.modals = []; // Close the modal after deletion
+    },
+  });
 }
+
 // Function to format date
 function formatNotificationDate(dateString) {
   const date = new Date(dateString);


### PR DESCRIPTION
## #️⃣연관된 이슈
- close #171 

## 🪄변경 사항
- 로그아웃 시에 헤더에서 알림 아이콘 숨김
- 알림 목록에서 알림 삭제 버튼 클릭 시 모달창 적용

## 🖼️결과 화면 (선택) 
![{A098955C-CEF0-4CE8-930D-1982BDE626BF}](https://github.com/user-attachments/assets/927728ed-096b-4b65-8ac1-d6c89e8c379a)

![{17C458C8-F68B-4F5C-8C78-33022A4144C1}](https://github.com/user-attachments/assets/a7163d90-5bd7-4916-ab17-de8953f3f5ed)


## 🗨️리뷰어에게 전할 말 (선택) 
