### PR TITLE
[merge / 182-profile-button-color] ✨Feat: 프로필 편집 버튼 왼쪽 정렬 / 게시물 보드, 사이드바, 팔로잉 목록 사진 1:1 비율 자름

### DIFF
--- a/src/components/common/Sidebar.vue
+++ b/src/components/common/Sidebar.vue
@@ -67,7 +67,7 @@ async function handleLogout() {
               :to="`/mypage/profile/${authStore.user.id}`"
             >
               <img
-                class="w-10 h-10 rounded-full"
+                class="w-10 h-10 rounded-full object-cover"
                 :src="authStore.profile.profile_url"
                 alt="사용자의 프로필 이미지입니다."
               />
@@ -171,5 +171,9 @@ async function handleLogout() {
 }
 #headersRef {
   z-index: 20;
+}
+
+.object-cover {
+  object-fit: cover;
 }
 </style>

--- a/src/pages/Follow.vue
+++ b/src/pages/Follow.vue
@@ -131,7 +131,7 @@ onMounted(() => {
                 <img
                   :src="user.profile_url"
                   :alt="user.username"
-                  class="w-12 h-12 rounded-full"
+                  class="w-12 h-12 rounded-full object-cover"
                 />
                 <div>
                   <p class="text-xm sm:text-xl font-semibold">
@@ -191,7 +191,7 @@ onMounted(() => {
                 <img
                   :src="user.profile_url"
                   :alt="user.username"
-                  class="w-12 h-12 rounded-full"
+                  class="w-12 h-12 rounded-full object-cover"
                 />
                 <div>
                   <p class="text-xl font-semibold">@{{ user.username }}</p>
@@ -234,5 +234,9 @@ onMounted(() => {
   scrollbar-width: none; /* Firefox */
 }
 @media (min-width: 768px) {
+}
+
+.object-cover {
+  object-fit: cover;
 }
 </style>

--- a/src/pages/community-pages/CommunityBoard.vue
+++ b/src/pages/community-pages/CommunityBoard.vue
@@ -175,7 +175,7 @@ onMounted(fetchPosts);
             <div class="flex flex-col sm:gap-7 xm:gap-6">
               <span class="flex items-center gap-[10px]">
                 <img
-                  class="aspect-square xm:w-[30px] sm:w-[50px] rounded-full"
+                  class="aspect-square xm:w-[30px] sm:w-[50px] rounded-full object-cover"
                   :src="
                     authorCache[post.author_id]?.profile_url || imgPlaceholder
                   "
@@ -195,7 +195,7 @@ onMounted(fetchPosts);
               </span>
             </div>
             <img
-              class="sm:w-[180px] sm:h-[180px] w-[100px] h-[100px] rounded-[20px]"
+              class="sm:w-[180px] sm:h-[180px] w-[100px] h-[100px] rounded-[20px] object-cover"
               :src="
                 Object.keys(postImgs[post.id] || {}).length === 0
                   ? imgPlaceholder
@@ -262,5 +262,9 @@ input {
   align-items: center;
   justify-content: center;
   margin: 0 auto;
+}
+
+.object-cover {
+  object-fit: cover;
 }
 </style>

--- a/src/pages/my-pages/Profile.vue
+++ b/src/pages/my-pages/Profile.vue
@@ -226,22 +226,18 @@ watch(
   <div
     class="w-full max-w-[1156px] mx-auto relative pt-[0px] sm:pt-[64px] sm:min-h-screen"
   >
-    <!-- 프로필 섹션과 버튼을 묶는 컨테이너 -->
     <div
       class="w-full sm:border-[7px] border-hc-white/50 sm:rounded-[20px] bg-hc-white/30 overflow-y-auto no-scrollbar"
       style="box-shadow: -4px 4px 50px 0 rgba(114, 158, 203, 0.7)"
     >
-      <!-- 프로필 섹션 -->
       <div
-        class="profile-container w-full sm:w-[830px] mx-auto pt-[48px] sm:pt-[138px] px-2 sm:px-0 flex flex-col xm:flex-row items-start gap-16 sm:gap-4"
+        class="profile-container w-full sm:w-[830px] mx-auto pt-[48px] sm:pt-[138px] px-2 sm:px-0 flex flex-col xm:flex-row items-start gap-16 sm:gap-4 sm:justify-between"
       >
         <div class="profile-section flex gap-4 sm:gap-12 items-start">
-          <!-- 프로필 사진 -->
           <img
             :src="userData.profile_url"
             class="w-[120px] sm:w-[160px] h-[120px] sm:h-[160px] rounded-full object-cover"
           />
-          <!-- 프로필 정보 -->
           <div class="flex flex-col gap-4">
             <div class="flex items-center gap-4 sm:gap-8">
               <p class="text-2xl sm:text-4xl font-semibold">
@@ -251,7 +247,6 @@ watch(
             <p class="text-xm sm:text-[30px]">
               {{ userData.profile_bio || "소개 없음" }}
             </p>
-            <!-- 게시물, 팔로워, 팔로잉 섹션 -->
             <div class="stats-container flex gap-6 text-xm sm:text-[30px]">
               <div class="flex items-center gap-2">
                 <p>게시물</p>
@@ -279,9 +274,8 @@ watch(
           </div>
         </div>
 
-        <!-- 프로필 편집 버튼 -->
         <div
-          class="edit-profile-btn w-full xm:w-auto flex justify-center items-center"
+          class="edit-profile-btn w-full xm:w-auto flex justify-center xm:justify-start items-center sm:justify-end"
         >
           <template v-if="loggedInUserId === userId">
             <router-link
@@ -305,7 +299,7 @@ watch(
               class="px-6 py-2 w-[550px] sm:w-[160px] xm:w-[380px] sm:rounded-[20px] rounded-[30px] text-xl"
               :class="
                 isFollowing
-                  ? 'bg-hc-gray text-hc-white'
+                  ? 'bg-hc-white text-hc-blue'
                   : 'bg-hc-blue text-hc-white'
               "
             >


### PR DESCRIPTION
## #️⃣연관된 이슈
- close #182 

## 🪄변경 사항
- 프로필 페이지의 프로필 편집 버튼(팔로잉, 팔로우 버튼) 왼쪽 정렬
- 게시물 보드의 프로필 사진, 게시물 미리보기 사진 1:1 비율로 자름
- 사이드바의 프로필 사진 1:1 비율로 자름
- 팔로잉/모든 유저 목록의 프로필 사진 1:1 비율로 자름

## 🖼️결과 화면 (선택) 
![{C42F91DB-BF1C-4388-851A-4E276F7C2B94}](https://github.com/user-attachments/assets/a98876c0-1ac8-4260-b0e9-653cf2d22f62)

![{9A045AF2-EBD5-4DAE-9913-407E5BACD806}](https://github.com/user-attachments/assets/4c76d74b-ad1a-4f2b-9460-d36d2b99b4cc)

![{41654D93-D419-437B-9ADA-E39728A1E37F}](https://github.com/user-attachments/assets/f05cf07b-eb5c-449b-9f5e-70bb9fc15c39)

![{5D176D1F-E371-4337-B130-83176F960F83}](https://github.com/user-attachments/assets/7beb24a6-88f9-4ecf-8d23-0d472dbba87f)


## 🗨️리뷰어에게 전할 말 (선택) 
