### PR TITLE
[merge / 109-replace-expired-imgUrl ] 🐛 Fix:  꿈 일기 이미지 스토리지에서 img_url로 불러오기

### DIFF
--- a/src/api/api-record/api.js
+++ b/src/api/api-record/api.js
@@ -23,3 +23,32 @@ export const checkDiaryExists = async (date) => {
     return false;
   }
 };
+export const uploadDiaryImage = async (diaryId, base64Image) => {
+  try {
+    const fileName = `${diaryId}.png`; // 일기 ID 기반 파일명
+    const filePath = `dream_img/${diaryId}/${fileName}`; // 폴더 경로
+
+    // Base64 -> Blob 변환
+    const blob = await (await fetch(base64Image)).blob();
+
+    // Supabase Storage에 업로드
+    const { data, error } = await supabase.storage
+      .from("MongSang_Img")
+      .upload(filePath, blob, {
+        contentType: "image/png",
+        upsert: true,
+      });
+
+    if (error) throw new Error(error.message);
+
+    // 업로드된 이미지의 URL 가져오기
+    const { data: publicUrlData } = supabase.storage
+      .from("MongSang_Img")
+      .getPublicUrl(filePath);
+
+    return publicUrlData.publicUrl;
+  } catch (error) {
+    console.error("이미지 업로드 실패:", error.message);
+    throw error;
+  }
+};

--- a/src/pages/diary-pages/DiaryDetails.vue
+++ b/src/pages/diary-pages/DiaryDetails.vue
@@ -101,7 +101,7 @@ const toggleModal = () => {
           class="absolute right-7 top-[89px] text-2xl text-justify text-black whitespace-nowrap"
         >
           <span class="font-semibold">{{ diaryData.username }}</span>
-          <span> 의 꿈 일기</span>
+          <span>의 꿈 일기</span>
         </p>
       </div>
 

--- a/src/pages/diary-pages/DiaryWrite.vue
+++ b/src/pages/diary-pages/DiaryWrite.vue
@@ -20,6 +20,8 @@ const props = defineProps({
   },
 });
 
+const { isDark } = useDarkMode();
+
 const emit = defineEmits(["submit"]);
 
 const selectedDate = ref(new Date());
@@ -60,6 +62,9 @@ const handleCheckButtonClick = async () => {
     content: content.value,
     condition: condition.value,
     weather: weather.value,
+    dream_analysis: diaryStore.dreamAnalysis,
+    img_url: diaryStore.imgUrl,
+    youtube_url: diaryStore.youtubeUrl,
   };
 
   if (props.isUpdateMode) {
@@ -68,9 +73,6 @@ const handleCheckButtonClick = async () => {
     const diary = {
       author_id: authStore.profile.id,
       ...diaryData,
-      dream_analysis: diaryStore.dreamAnalysis,
-      img_url: diaryStore.imgUrl,
-      youtube_url: diaryStore.youtubeUrl,
     };
 
     try {
@@ -156,8 +158,6 @@ onMounted(() => {
     }
   }
 });
-
-const { isDark } = useDarkMode();
 </script>
 
 <template>


### PR DESCRIPTION
## #️⃣연관된 이슈
- close #109 

## 🪄변경 사항
- 직접 open ai url 받아오는 것에서 => supabase 스토리지에 올린 뒤 dream 테이블의 img_url 에 update 후 img_url 받아오는 형식으로 변경함.

## 🖼️결과 화면 (선택) 
<img width="545" alt="image" src="https://github.com/user-attachments/assets/38221140-8ff8-419d-a4e1-90b074238c66" />


## 🗨️리뷰어에게 전할 말 (선택) 
- ε=ε=ε=┏(゜ロ゜;)┛