### PR TITLE
[merge / 216-restrict-record] 🐛 fix: 로그인이 안된 상태에서는 꿈 기록 페이지 접근 제한

### DIFF
--- a/src/pages/Record.vue
+++ b/src/pages/Record.vue
@@ -11,12 +11,17 @@ import {
   mdiMicrophoneOff,
 } from "@mdi/js";
 import { ref, onMounted } from "vue";
-import { useRoute, onBeforeRouteLeave } from "vue-router";
+import { useRoute, onBeforeRouteLeave, useRouter } from "vue-router";
 import { OpenAI } from "openai";
 import { useDiaryStore } from "@/store/diaryStore";
+import { useModalStore } from "@/store/modalStore";
+import { useAuthStore } from "@/store/authStore";
 import { checkDiaryExists, uploadDiaryImage } from "@/api/api-record/api";
 import { useDarkMode } from "@/utils/darkMode";
 const diaryStore = useDiaryStore();
+const modalStore = useModalStore();
+const authStore = useAuthStore();
+const router = useRouter();
 
 const isDiaryWritten = ref(false);
 const today = new Date().toISOString().split("T")[0];
@@ -42,6 +47,21 @@ const { isDark } = useDarkMode();
 
 //일기 작성 페이지를 제외한 다른 페이지 이동 시 데이터 초기화
 const route = useRoute();
+
+onMounted(() => {
+  if (!authStore.profile?.id) {
+    modalStore.addModal({
+      title: "로그인 필요",
+      content: "로그인 후 이용해주세요.",
+      btnText: "로그인",
+      isOneBtn: true,
+      onClick: () => {
+        modalStore.modals = [];
+        router.push({ name: "login" });
+      },
+    });
+  }
+});
 
 onBeforeRouteLeave((to) => {
   if (to.path !== "/diary/write") {


### PR DESCRIPTION
## #️⃣연관된 이슈
- close #216 

## 🪄변경 사항
- 로그인이 안된 상태에서는 꿈 기록 페이지 접근 제한 

## 🖼️결과 화면 (선택) 
<img width="1277" alt="image" src="https://github.com/user-attachments/assets/63eb259d-a16d-4018-b932-ca4e4434067b" />


## 🗨️리뷰어에게 전할 말 (선택) 
( •̀ ω •́ )y 화이팅